### PR TITLE
Run Github Actions on pull request events

### DIFF
--- a/.github/workflows/session_0.yaml
+++ b/.github/workflows/session_0.yaml
@@ -1,6 +1,6 @@
 name: 'Session 0'
 
-on: push
+on: [push, pull_request]
 
 jobs:
   session-0:

--- a/.github/workflows/session_1.yaml
+++ b/.github/workflows/session_1.yaml
@@ -1,6 +1,6 @@
 name: 'Session 1'
 
-on: push
+on: [push, pull_request]
 
 jobs:
   session-1:


### PR DESCRIPTION
The Github Actions are not run by default on pull requests - something that was masked as we only pushed straight to the primary repository instead of working with forks. As pushing to the primary repository is arguably a bad practice (on public repositories), support the forking workflow and run Github Actions on pull request events as well.